### PR TITLE
Adds note about $rules on models

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Will output:
 
 If there is a validation error on the field, it will output:
 
-	<div class="row">
-		<div class="form-group col-md-6 col-md-offset-3 has-error">
+    <div class="row">
+        <div class="form-group col-md-6 col-md-offset-3 has-error">
             <label for="name">Name</label>
             <input id="name" placeholder="Name" maxlength="150"
-            	class="form-control" name="name" type="text"
-            	value="">
+                class="form-control" name="name" type="text"
+                value="">
             <span class="help-block">The name field is required.</small>
         </div>
     </div>
@@ -38,8 +38,8 @@ Installation
 1. Require `"npmweb/laravel-forms": "~1.0"` in your `composer.json` file.
 2. Run `composer install` or `composer update` to download it and have the autoloader updated.
 3. Open `app/config/app.php` and make the following changes under the `providers` key:
-	a. Comment out `'Illuminate\Html\HtmlServiceProvider'`
-	b. Add `'NpmWeb\FormBuilder\HtmlServiceProvider'`
+    a. Comment out `'Illuminate\Html\HtmlServiceProvider'`
+    b. Add `'NpmWeb\FormBuilder\HtmlServiceProvider'`
 
 Configuration
 =============
@@ -62,6 +62,22 @@ Here's some more information about the included drivers:
 
 Usage
 =====
+
+**NOTE**: your **$rules** on models must be in **array** format vs. **string** format!
+```php
+class Post {
+    
+    /**
+     * Validation rules for a Post
+     * @type Array
+     */
+    public static $rules = [
+        'title' => ['required', 'max: 140'],
+        'body' => ['required', 'max:2000'],
+    ];
+
+}
+```
 
 Just use any of Laravel's normal `Form::` methods, such as `Form::text()` or `Form::select()`. Instead of outputting the bare form control, it will also output the wrapping DOM elements appropriate to your selected CSS framework.
 


### PR DESCRIPTION
$rules must be in array format, not string format. Previously, this was not mentioned in the docs. I spent half an hour trying to figure out why Form::model() didn't work, and this was the reason. Hopefully, this will save others time in the future.